### PR TITLE
Cleanup

### DIFF
--- a/src/fitter/analysis.py
+++ b/src/fitter/analysis.py
@@ -12,10 +12,8 @@ import fitter.load_data as ld
 import fitter.plotting as plot
 
 
-def run_stability(states, xp, x, y, gv_data, data_cfg,
-                  es_stability=False, svd_test=True,
-                  save_figs=False, scale=[]):
-
+def run_stability(args, xp, x, y, gv_data, data_cfg):
+    states = args.stability
     for state in states:
         if 't_sweep' in xp.corr_lst[state]:
             tmin = xp.corr_lst[state]['t_sweep']
@@ -43,7 +41,7 @@ def run_stability(states, xp, x, y, gv_data, data_cfg,
                 if state not in k:
                     p_tmp.pop(k)
 
-            if svd_test:
+            if args.svd_test:
                 has_svd = True
                 svd_test, svdcut = ld.svd_diagnose(y_tmp, data_cfg, x_tmp)
                 has_svd = True
@@ -76,39 +74,39 @@ def run_stability(states, xp, x, y, gv_data, data_cfg,
         ylim = None
 
         plot.plot_stability(fits, tmin, n_states, tn_opt,
-                            state, ylim=ylim, save=save_figs, scale=scale)
-        if es_stability:
+                            state, ylim=ylim, save=args.save_figs, scale=args.scale)
+        if args.es_stability:
             for i_n in range(1, n_states[-1]):
                 plot.plot_stability(fits, tmin, n_states, tn_opt, state,
-                                    ylim=ylim, save=save_figs, n_plot=i_n, scale=scale)
+                                    ylim=ylim, save=args.save_figs, n_plot=i_n, scale=args.scale)
 
 
-def run_bootstrap(bs_results, bs_write, bs_path, overwrite, Nbs, bs_seed, fit, fp, data_cfg, x_fit, svdcut=None, verbose=False):
+def run_bootstrap(args, fit, fp, data_cfg, x_fit, svdcut=None):
 
     # make sure results dir exists
-    if bs_write:
+    if args.bs_write:
         if not os.path.exists('bs_results'):
             os.makedirs('bs_results')
-    if len(bs_results.split('/')) == 1:
-        bs_file = 'bs_results/'+bs_results
+    if len(args.bs_results.split('/')) == 1:
+        bs_file = 'bs_results/'+args.bs_results
     else:
-        bs_file = bs_results
+        bs_file = args.bs_results
 
     # check if we already wrote this dataset
-    if bs_write:
+    if args.bs_write:
         have_bs = False
         if os.path.exists(bs_file):
             with h5py.File(bs_file, 'r') as f5:
-                if bs_path in f5:
-                    if len(f5[bs_path]) > 0 and not overwrite:
+                if args.bs_path in f5:
+                    if len(f5[args.bs_path]) > 0 and not args.overwrite:
                         have_bs = True
                         print(
-                            'you asked to write bs results to an existing dset and overwrite =', overwrite)
+                            'you asked to write bs results to an existing dset and overwrite =', args.overwrite)
     else:
         have_bs = False
 
     if not have_bs:
-        print('beginning Nbs=%d bootstrap fits' % Nbs)
+        print('beginning Nbs=%d bootstrap fits' % args.Nbs)
         import fitter.bs_utils as bs
         fit_funcs = cf.FitCorr()
 
@@ -118,7 +116,7 @@ def run_bootstrap(bs_results, bs_write, bs_path, overwrite, Nbs, bs_seed, fit, f
             p0_bs[k] = fit.p[k].mean
 
         # seed bs random number generator
-        if not bs_seed and 'bs_seed' not in dir(fp):
+        if not args.bs_seed and 'bs_seed' not in dir(fp):
             tmp = input('you have not passed a BS seed nor is it defined in the input file\nenter a seed or hit return for none')
             if not tmp:
                 bs_seed = None
@@ -126,19 +124,19 @@ def run_bootstrap(bs_results, bs_write, bs_path, overwrite, Nbs, bs_seed, fit, f
                 bs_seed = tmp
         elif 'bs_seed' in dir(fp):
             bs_seed = fp.bs_seed
-        if bs_seed:
-            if verbose:
+        if args.bs_seed:
+            if args.verbose:
                 print('WARNING: you are overwriting the bs_seed from the input file')
-            bs_seed = bs_seed
+            bs_seed = args.bs_seed
 
         # create bs_list
         Ncfg = data_cfg[next(iter(data_cfg))].shape[0]
-        bs_list = bs.get_bs_list(Ncfg, Nbs, seed=bs_seed)
+        bs_list = bs.get_bs_list(Ncfg, args.Nbs, seed=bs_seed)
 
         # make BS list for priors
         p_bs_mean = dict()
         for k in fit.prior:
-            p_bs_mean[k] = bs.bs_prior(Nbs, mean=fit.prior[k].mean,
+            p_bs_mean[k] = bs.bs_prior(args.Nbs, mean=fit.prior[k].mean,
                                     sdev=fit.prior[k].sdev, seed=bs_seed+'_'+k)
 
         # set up posterior lists of bs results
@@ -147,7 +145,7 @@ def run_bootstrap(bs_results, bs_write, bs_path, overwrite, Nbs, bs_seed, fit, f
             post_bs[k] = []
 
         # loop over bootstraps
-        for bs in tqdm.tqdm(range(Nbs)):
+        for bs in tqdm.tqdm(range(args.Nbs)):
             ''' all gvar's created in this switch are destroyed at restore_gvar
                 [they are out of scope] '''
             gv.switch_gvar()
@@ -187,18 +185,18 @@ def run_bootstrap(bs_results, bs_write, bs_path, overwrite, Nbs, bs_seed, fit, f
 
         for r in post_bs:
             post_bs[r] = np.array(post_bs[r])
-        if bs_write:
+        if args.bs_write:
             # write the results
             with h5py.File(bs_file, 'a') as f5:
                 try:
-                    f5.create_group(bs_path)
+                    f5.create_group(args.bs_path)
                 except Exception as e:
                     print(e)
                 for r in post_bs:
                     if len(post_bs[r]) > 0:
-                        if r in f5[bs_path]:
-                            del f5[bs_path+'/'+r]
-                        f5.create_dataset(bs_path+'/'+r, data=post_bs[r])
+                        if r in f5[args.bs_path]:
+                            del f5[args.bs_path+'/'+r]
+                        f5.create_dataset(args.bs_path+'/'+r, data=post_bs[r])
 
         return post_bs
     else:

--- a/src/fitter/bs_utils.py
+++ b/src/fitter/bs_utils.py
@@ -98,7 +98,7 @@ def bs_corrs(corr, Nbs, Mbs=None, seed=None, return_bs_list=False, return_mbs=Fa
         return corr_bs
 
 
-def bs_prior(Nbs, mean=0., sdev=1., seed=None):
+def bs_prior(Nbs, mean=0., sdev=1., seed=None, dist='normal'):
     ''' Generate bootstrap distribution of prior central values
         Args:
             Nbs  : number of values to return
@@ -111,8 +111,12 @@ def bs_prior(Nbs, mean=0., sdev=1., seed=None):
     # seed the random number generator
     rng = get_rng(seed) if seed else np.random.default_rng()
 
-    return rng.normal(loc=mean, scale=sdev, size=Nbs)
-
+    if dist == 'normal':
+        return rng.normal(loc=mean, scale=sdev, size=Nbs)
+    elif dist == 'lognormal':
+        return rng.lognormal(mean=mean, sigma=sdev, size=Nbs)
+    else:
+        sys.exit('you have not given a known distribution, %s' %dist)
 
 def block_data(data, bl):
     ''' Generate "blocked" or "binned" data from original data

--- a/src/fitter/fit_twopt.py
+++ b/src/fitter/fit_twopt.py
@@ -52,8 +52,14 @@ def main():
                         help=            'run bootstrap fit? [%(default)s]')
     parser.add_argument('--Nbs',         type=int, default=2000,
                         help=            'specify the number of BS samples to compute [%(default)s]')
+    parser.add_argument('--Mbs',         type=int, default=None,
+                        help=            'number of random draws per bootstrap sample [%(default)s]')
     parser.add_argument('--bs_seed',     default=None,
                         help=            'set a string to seed the bootstrap - None will be random [%(default)s]')
+    parser.add_argument('--bs0_restrict',default=True, action='store_false',
+                        help=            'constrain ground state mean sampling with b0 posterior')
+    parser.add_argument('--bs0_width',   type=float, default=5.0,
+                        help=            'multiplication factor of posterior width for ground state prior mean sampling')
     parser.add_argument('--bs_write',    default=True, action='store_false',
                         help=            'write bs results to file? [%(default)s]')
     parser.add_argument('--bs_results',  default='bs_results/spectrum_bs.h5',
@@ -169,7 +175,7 @@ def main():
 
         # Bootstrap
         if args.bs:
-            bs_results = analysis.run_bootstrap(args, fit, fp, data_cfg, x_fit)
+            bs_results, bs_fit_report = analysis.run_bootstrap(args, fit, fp, data_cfg, x_fit)
 
         if args.svd_test and args.eff:
             fig = plt.figure('svd_diagnosis', figsize=(7, 4))

--- a/src/fitter/fit_twopt.py
+++ b/src/fitter/fit_twopt.py
@@ -130,9 +130,7 @@ def main():
 
     # run a stability analysis
     if args.stability:
-        analysis.run_stability(args.stability, fp, x, y, gv_data, data_cfg,
-                          es_stability=args.es_stability, svd_test=args.svd_test,
-                          save_figs=args.save_figs, scale=args.scale)
+        analysis.run_stability(args, fp, x, y, gv_data, data_cfg)
 
     if args.fit:
         fit_funcs = cf.FitCorr()
@@ -171,7 +169,7 @@ def main():
 
         # Bootstrap
         if args.bs:
-            bs_results = analysis.run_bootstrap(args.bs_results, args.bs_write, args.bs_path, args.overwrite, args.Nbs, args.bs_seed, fit, fp, data_cfg, x_fit, args.verbose)
+            bs_results = analysis.run_bootstrap(args, fit, fp, data_cfg, x_fit)
 
         if args.svd_test and args.eff:
             fig = plt.figure('svd_diagnosis', figsize=(7, 4))

--- a/src/fitter/plotting.py
+++ b/src/fitter/plotting.py
@@ -102,9 +102,7 @@ class EffectivePlots():
                 self.ax['z_'+k].set_ylabel(r'$z_{\rm eff}^{\rm %s}(t)$' % k, fontsize=20)
                 self.ax['z_'+k].legend(fontsize=20, loc=1)
 
-    def plot_eff_fit(self,
-        x_fit,
-        fit, ):
+    def plot_eff_fit(self, x_fit, fit):
         '''
             x_fit: parameters for fit
             fit  : result of lsqfit.nonlinear_fit
@@ -113,7 +111,10 @@ class EffectivePlots():
 
         x_plot = copy.deepcopy(x_fit)
         for k_sp in x_plot:
-            k,sp = k_sp.split('_')
+            if 'mres' in k_sp:
+                k = k_sp
+            else:
+                k,sp = k_sp.split('_')
             ax = self.ax['m_'+k]
 
             if 't0' in x_fit[k_sp]:

--- a/tests/input_file/a09m310_test.py
+++ b/tests/input_file/a09m310_test.py
@@ -1,7 +1,7 @@
 import gvar as gv
 import numpy as np
 
-data_file = 'data/callat_a09m310_test.h5'
+data_file = 'data/callat_test.h5'
 
 fit_states = ['mres-L','mres-S', 'pion', 'kaon', 'proton', 'omega']
 #fit_states = ['pion', 'kaon', 'proton', 'omega']

--- a/tests/input_file/a12m310_test.py
+++ b/tests/input_file/a12m310_test.py
@@ -1,0 +1,169 @@
+import gvar as gv
+import numpy as np
+
+data_file = 'data/callat_test.h5'
+
+fit_states = ['mres-L','mres-S', 'pion', 'kaon', 'proton']
+#fit_states = ['pion', 'kaon', 'proton', 'omega']
+bs_seed = 'a12m310'
+
+corr_lst = {
+    # PION
+    'pion':{
+        'dsets':['a12m310/pion'],
+        'weights'  :[1],
+        't_reverse':[False],
+        'fold'     :True,
+        'snks'     :['S', 'P'],
+        'srcs'     :['S'],
+        'xlim'     :[0,32.5],
+        'ylim'     :[0.16,0.22],
+        'colors'   :{'SS':'#70bf41','PS':'k'},
+        'type'     :'cosh',
+        'ztype'    :'z_snk z_src',
+        'z_ylim'   :[0.055,0.26],
+        # fit params
+        'n_state'  :3,
+        'T'        :64,
+        't_range'  :np.arange(5,32),
+        't_sweep'  :range(2,28),
+        'n_sweep'  :range(1,6),
+        'eff_ylim' :[0.133,0.1349]
+    },
+    # KAON
+    'kaon':{
+        'dsets':['a12m310/kaon'],
+        'weights'  :[1],
+        't_reverse':[False],
+        'fold'     :True,
+        'snks'     :['S', 'P'],
+        'srcs'     :['S'],
+        'xlim'     :[0,32.5],
+        'ylim'     :[0.3,0.35],
+        'colors'   :{'SS':'#70bf41','PS':'k'},
+        'type'     :'cosh',
+        'ztype'    :'z_snk z_src',
+        'z_ylim'   :[0.055,0.26],
+        # fit params
+        'n_state'  :4,
+        'T'        :64,
+        't_range'  :np.arange(8,32),
+        't_sweep'  :range(2,28),
+        'n_sweep'  :range(1,6),
+        'eff_ylim' :[0.133,0.1349]
+    },
+    # MRES_L
+    'mres-L':{
+        'corr_array':False,
+        'dset_MP'   :['a12m310/mp_ml0p0126'],
+        'dset_PP'   :['a12m310/pp_ml0p0126'],
+        'weights'   :[1],
+        't_reverse' :[False],
+        'fold'      :True,
+        'T'         :64,
+        'snks'      :['M', 'P'],
+        'srcs'      :['P'],
+        'xlim'      :[0,32.5],
+        'ylim'      :[4e-4,12e-4],
+        'colors'    :'#70bf41',
+        'type'      :'mres',
+        # fit params
+        't_range'   :np.arange(10,49),
+        't_sweep'   :range(2,28),
+    },
+    # MRES_S
+    'mres-S':{
+        'corr_array':False,
+        'dset_MP'   :['a12m310/mp_ms0p0693'],
+        'dset_PP'   :['a12m310/pp_ms0p0693'],
+        'weights'   :[1],
+        't_reverse' :[False],
+        'fold'      :True,
+        'T'         :96,
+        'snks'      :['M', 'P'],
+        'srcs'      :['P'],
+        'xlim'      :[0,48.5],
+        'ylim'      :[3e-4,8e-4],
+        'colors'    :'#70bf41',
+        'type'      :'mres',
+        # fit params
+        't_range'   :np.arange(10,49),
+        't_sweep'   :range(2,28),
+    },
+    # PROTON
+    'proton':{
+        'dsets':['a12m310/nucleon'],
+        'weights'  :[1.],
+        't_reverse':[False],
+        'phase'    :[1],
+        'fold'     :False,
+        'snks'     :['S', 'P'],
+        'srcs'     :['S'],
+        'xlim'     :[0,20.5],
+        'ylim'     :[0.6,0.74],
+        'colors'   :{'SS':'#70bf41','PS':'k'},
+        'type'     :'exp',
+        'ztype'    :'z_snk z_src',
+        'z_ylim'   :[0.,0.0039],
+        # fit params
+        'n_state'  :3,
+        't_range'  :np.arange(5,17),
+        't_sweep'  :range(2,16),
+        'n_sweep'  :range(1,6),
+    },
+
+}
+
+priors = gv.BufferDict()
+x      = dict()
+
+priors['proton_E_0']  = gv.gvar(0.66, .04)
+priors['proton_zS_0'] = gv.gvar(2.0e-5, 1.e-5)
+priors['proton_zP_0'] = gv.gvar(2.5e-3, 1.e-3)
+
+priors['pion_E_0']  = gv.gvar(0.19, .01)
+priors['pion_zS_0'] = gv.gvar(5e-3, 5e-4)
+priors['pion_zP_0'] = gv.gvar(0.125,  0.015)
+
+priors['kaon_E_0']  = gv.gvar(0.325, .01)
+priors['kaon_zS_0'] = gv.gvar(4e-3, 5e-5)
+priors['kaon_zP_0'] = gv.gvar(0.1, 0.025)
+
+priors['mres-L']    = gv.gvar(7.5e-4, 1e-4)
+priors['mres-S']    = gv.gvar(5e-4, 5e-5)
+
+for corr in corr_lst:#[k for k in corr_lst if 'mres' not in k]:
+    if 'mres' not in corr:
+        for n in range(1,10):
+            # use 2 mpi splitting for each dE
+
+            # E_n = E_0 + dE_10 + dE_21 +...
+            # use log prior to force ordering of dE_n
+            priors['log(%s_dE_%d)' %(corr,n)] = gv.gvar(np.log(2*priors['pion_E_0'].mean), 0.7)
+
+            # for z_P, no suppression with n, but for S, smaller overlaps
+            priors['%s_zP_%d' %(corr,n)] = gv.gvar(priors['%s_zP_0' %(corr)].mean, 2*priors['%s_zP_0' %(corr)].sdev)
+            zS_0 = priors['%s_zS_0' %(corr)]
+            if n <= 2:
+                priors['%s_zS_%d' %(corr,n)] = gv.gvar(zS_0.mean, 2*zS_0.sdev)
+            else:
+                priors['%s_zS_%d' %(corr,n)] = gv.gvar(zS_0.mean/2, zS_0.sdev)
+    # x-params
+    for snk in corr_lst[corr]['snks']:
+        sp = snk+corr_lst[corr]['srcs'][0]
+        state = corr+'_'+sp
+        x[state] = dict()
+        x[state]['state'] = corr
+        for k in ['type', 'T', 'n_state', 't_range', 'eff_ylim', 'ztype']:
+            if k in corr_lst[corr]:
+                x[state][k] = corr_lst[corr][k]
+        if 't0' in corr_lst[corr]:
+            x[state]['t0'] = corr_lst[corr]['t0']
+        else:
+            x[state]['t0'] = 0
+        if 'mres' not in corr:
+            x[state]['color'] = corr_lst[corr]['colors'][sp]
+            x[state]['snk']   = snk
+            x[state]['src']   = corr_lst[corr]['srcs'][0]
+        else:
+            x[state]['color'] = corr_lst[corr]['colors']


### PR DESCRIPTION
this fixes an issue encountered with bootstrapping - log normal priors were accidentally sampled with normal when getting the mean value of the prior.  We also added a feature to restrict the ground state priors with n-sigma from boot0 posterior where `n=4` by default but can be changed by the user